### PR TITLE
Movable allocation plugin

### DIFF
--- a/coldfront/components/site/templates/allocation/allocation_detail.html
+++ b/coldfront/components/site/templates/allocation/allocation_detail.html
@@ -41,8 +41,13 @@ Allocation Detail
           <h3><i class="fas fa-list" aria-hidden="true"></i> Allocation Information</h3>
         </div>
         <div class="col">
+          {% if allocation_moving_enabled %}
+            {% if user_has_permissions %}
+              <a href="{% url 'move-allocation' allocation.pk %}" class="btn btn-primary" role="button" style="float: right;">Move Allocation</a>
+            {% endif %}
+          {% endif %}
           {% if allocation.is_changeable and allocation.status.name == 'Active' %}
-            <a class="btn btn-primary" href="{% url 'allocation-change' allocation.pk %}" role="button" style="float: right;">
+            <a class="btn btn-primary mr-1" href="{% url 'allocation-change' allocation.pk %}" role="button" style="float: right;">
               Request Change
             </a>
           {% endif %}

--- a/coldfront/config/plugins/movable_allocations.py
+++ b/coldfront/config/plugins/movable_allocations.py
@@ -1,0 +1,6 @@
+from coldfront.config.base import INSTALLED_APPS
+
+
+INSTALLED_APPS += [
+    'coldfront.plugins.movable_allocations',
+]

--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -33,7 +33,8 @@ plugin_configs = {
     'PLUGIN_CUSTOMIZABLE_FORMS': 'plugins/customizable_forms.py',
     'PLUGIN_PI_SEARCH': 'plugins/pi_search.py',
     'PLUGIN_ALLOCATION_REMOVAL_REQUESTS':'plugins/allocation_removal_requests.py',
-    'PLUGIN_ANNOUNCEMENTS': 'plugins/announcements.py'
+    'PLUGIN_ANNOUNCEMENTS': 'plugins/announcements.py',
+    'PLUGIN_MOVABLE_ALLOCATIONS': 'plugins/movable_allocations.py'
 }
 
 # This allows plugins to be enabled via environment variables. Can alternatively

--- a/coldfront/config/urls.py
+++ b/coldfront/config/urls.py
@@ -33,7 +33,10 @@ if settings.PUBLICATION_ENABLE:
 if settings.RESEARCH_OUTPUT_ENABLE:
     urlpatterns.append(path('research-output/', include('coldfront.core.research_output.urls')))
 
-if 'coldfront_custom_resources' in settings.INSTALLED_APPS: 
+if 'coldfront.plugins.movable_allocations' in settings.INSTALLED_APPS:
+    urlpatterns.append(path('movable_allocations/', include('coldfront.plugins.movable_allocations.urls')))
+
+if 'coldfront_custom_resources' in settings.INSTALLED_APPS:
     urlpatterns.append(path('custom_resources/', include('coldfront_custom_resources.urls')))
 
 if 'coldfront.plugins.announcements' in settings.INSTALLED_APPS:

--- a/coldfront/core/allocation/utils.py
+++ b/coldfront/core/allocation/utils.py
@@ -165,6 +165,10 @@ def create_admin_action(user, fields_to_check, allocation, base_model=None):
                 status_class = base_model._meta.get_field('status').remote_field.model
                 base_model_value = status_class.objects.get(pk=base_model_value).name
                 value = value.name
+            if key == 'project':
+                project_class = base_model._meta.get_field('project').remote_field.model
+                base_model_value = project_class.objects.get(pk=base_model_value).pk
+                value = value.pk
         if value != base_model_value:
             AllocationAdminAction.objects.create(
                 user=user,

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -196,6 +196,12 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
         context['user_exists_in_allocation'] = allocation_obj.allocationuser_set.filter(
             user=self.request.user, status__name__in=['Active', 'Pending - Remove', 'Invited', 'Pending', 'Disabled', 'Retired']).exists()
 
+        context['allocation_moving_enabled'] = False
+        if 'coldfront.plugins.movable_allocations' in settings.INSTALLED_APPS:
+            is_moveable = allocation_obj.allocationattribute_set.filter(
+                allocation_attribute_type__name='Is Moveable').first()
+            context['allocation_moving_enabled'] = is_moveable and is_moveable.value == 'Yes'
+
         context['project'] = allocation_obj.project
         context['notes'] = notes
         context['ALLOCATION_ENABLE_ALLOCATION_RENEWAL'] = ALLOCATION_ENABLE_ALLOCATION_RENEWAL

--- a/coldfront/core/project/models.py
+++ b/coldfront/core/project/models.py
@@ -359,7 +359,7 @@ required to log onto the site at least once before they can be added.
     @property
     def get_env(self):
         if not PROJECT_ENABLE_PERMISSIONS_PER_TYPE or PROJECT_PERMISSIONS_PER_TYPE.get(self.type.name) is None:
-            return PROJECT_ENABLE_PERMISSIONS_PER_TYPE.get('Default')
+            return PROJECT_PERMISSIONS_PER_TYPE.get('Default')
         merged = PROJECT_PERMISSIONS_PER_TYPE.get('Default') | PROJECT_PERMISSIONS_PER_TYPE.get(self.type.name)
         return merged
 

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1828,7 +1828,7 @@ class ProjectReviewCompleteView(LoginRequiredMixin, UserPassesTestMixin, View):
         return HttpResponseRedirect(reverse('project-review-list'))
 
 
-class ProjectReivewEmailView(LoginRequiredMixin, UserPassesTestMixin, FormView):
+class ProjectReviewEmailView(LoginRequiredMixin, UserPassesTestMixin, FormView):
     form_class = ProjectReviewEmailForm
     template_name = 'project/project_review_email.html'
     login_url = "/"

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1764,7 +1764,7 @@ class ProjectReviewListView(LoginRequiredMixin, UserPassesTestMixin, TemplateVie
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['project_review_list'] = ProjectReview.objects.filter(
-            status__name__in=['Pending', 'COntacted By Admin', ])
+            status__name__in=['Pending', 'Contacted By Admin', ])
         projects = Project.objects.filter(
             status__name__in=['Waiting For Admin Approval', 'Contacted By Admin', ]
         )

--- a/coldfront/plugins/movable_allocations/admin.py
+++ b/coldfront/plugins/movable_allocations/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/coldfront/plugins/movable_allocations/apps.py
+++ b/coldfront/plugins/movable_allocations/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class MovableAllocationsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'coldfront.plugins.movable_allocations'

--- a/coldfront/plugins/movable_allocations/forms.py
+++ b/coldfront/plugins/movable_allocations/forms.py
@@ -5,7 +5,7 @@ from coldfront.core.project.models import Project
 
 
 class AllocationMoveForm(forms.Form):
-    new_project = forms.ModelChoiceField(queryset=None)
+    destination_project = forms.ModelChoiceField(queryset=None)
     users = forms.MultipleChoiceField(widget=forms.CheckboxSelectMultiple, required=False)
 
     def __init__(self, request_user, project_pk, *args, **kwargs):
@@ -14,7 +14,7 @@ class AllocationMoveForm(forms.Form):
         if request_user == project_obj.pi:
             project_objs = Project.objects.filter(pi=request_user)
         project_objs = Project.objects.filter(status__name="Active").exclude(pk=project_obj.pk)
-        self.fields["new_project"].queryset = project_objs
+        self.fields["destination_project"].queryset = project_objs
         user_query_set = (
             project_obj.projectuser_set.select_related("user")
             .filter(

--- a/coldfront/plugins/movable_allocations/forms.py
+++ b/coldfront/plugins/movable_allocations/forms.py
@@ -1,0 +1,40 @@
+from django import forms
+from django.shortcuts import get_object_or_404
+
+from coldfront.core.project.models import Project
+
+
+class AllocationMoveForm(forms.Form):
+    new_project = forms.ModelChoiceField(queryset=None)
+    users = forms.MultipleChoiceField(widget=forms.CheckboxSelectMultiple, required=False)
+
+    def __init__(self, request_user, project_pk, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        project_obj = get_object_or_404(Project, pk=project_pk)
+        if request_user == project_obj.pi:
+            project_objs = Project.objects.filter(pi=request_user)
+        project_objs = Project.objects.filter(status__name="Active").exclude(pk=project_obj.pk)
+        self.fields["new_project"].queryset = project_objs
+        user_query_set = (
+            project_obj.projectuser_set.select_related("user")
+            .filter(
+                status__name__in=[
+                    "Active",
+                ]
+            )
+            .order_by("user__username")
+        )
+        user_query_set = user_query_set.exclude(user=project_obj.pi)
+        if user_query_set:
+            self.fields["users"].choices = (
+                (
+                    user.user.username,
+                    "%s %s (%s)" % (user.user.first_name, user.user.last_name, user.user.username),
+                )
+                for user in user_query_set
+            )
+            self.fields[
+                "users"
+            ].help_text = "<br/>Select users in this allocation to include in the move."
+        else:
+            self.fields["users"].widget = forms.HiddenInput()

--- a/coldfront/plugins/movable_allocations/models.py
+++ b/coldfront/plugins/movable_allocations/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/coldfront/plugins/movable_allocations/signals.py
+++ b/coldfront/plugins/movable_allocations/signals.py
@@ -1,0 +1,4 @@
+import django.dispatch
+
+
+allocation_moved = django.dispatch.Signal()

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_detail.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_detail.html
@@ -1,3 +1,0 @@
-<div>
-  Allocation Details
-</div>

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_detail.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_detail.html
@@ -1,0 +1,3 @@
+<div>
+  Allocation Details
+</div>

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
@@ -32,7 +32,12 @@ Move Allocation
         </div>
         <div class="card-body">
           <fieldset>
-            <legend><strong><u>Project Info</u></strong></legend>
+            <legend>
+              <strong><u>Project Info</u></strong>
+              <a href="{% url 'project-detail' allocation.project.pk %}" target="_blank">
+                <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+              </a>
+            </legend>
             <p><strong>ID:</strong> {{ allocation.project.pk }}</p>
             <p><strong>Title:</strong> {{ allocation.project.title }}</p>
             <p><strong>Project Description:</strong> {{ allocation.project.description }}</p>

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
@@ -34,6 +34,7 @@ Move Allocation
         <div class="card-body">
           <fieldset>
             <legend><strong><u>Project Info</u></strong></legend>
+            <p><strong>ID:</strong> {{ allocation.project.pk }}</p>
             <p><strong>Title:</strong> {{ allocation.project.title }}</p>
             <p><strong>Project Description:</strong> {{ allocation.project.description }}</p>
             <p><strong>Project Type:</strong> {{ allocation.project.type }}</p>

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
@@ -28,7 +28,7 @@ Move Allocation
     <div class="col">
       <div class="card">
         <div class="card-header">
-          <h3>Current Project</h3>
+          <h3>Current</h3>
         </div>
         <div class="card-body">
           <fieldset>
@@ -89,17 +89,17 @@ Move Allocation
         <div class="card-header">
           <div class="row">
             <div class="col">
-              <label for="id_new_project">
-                <h3 class="m-0">{{ form.new_project.label|title }}</h3>
+              <label for="id_destination_project">
+                <h3 class="m-0">Destination</h3>
               </label>
             </div>
             <div class="col">
-              {{ form.new_project }}
+              {{ form.destination_project }}
             </div>
           </div>
         </div>
         <div class="card-body">
-          <div id="id_new_project_info"></div>
+          <div id="id_destination_project_info"></div>
         </div>
         <div class="card-footer">
           <button id="id_submit" class="btn btn-primary float-right confirm-move" type="submit">
@@ -123,21 +123,21 @@ Move Allocation
     return confirmation
   })
   $(document).ready(function () {
-    $('#id_new_project').addClass('form-control')
-    $('#id_new_project').change(function (e) {
-      var project_pk = $("#id_new_project option:selected").val();
+    $('#id_destination_project').addClass('form-control')
+    $('#id_destination_project').change(function (e) {
+      var project_pk = $("#id_destination_project option:selected").val();
       if (!project_pk) {
-        $('#id_new_project_info').html('')
+        $('#id_destination_project_info').html('')
         return;
       }
 
-      $('#id_new_project_info').html(
+      $('#id_destination_project_info').html(
         '<i class="fas fa-sync fa-spin fa-fw" aria-hidden="true"></i> Grabbing project information...'
       );
       $.ajax({
         url: `project-info/${project_pk}`,
         success: function (data) {
-          $('#id_new_project_info').html(data)
+          $('#id_destination_project_info').html(data)
           var not_moveable = $('#id_not_moveable');
           console.log(not_moveable.length);
           if (not_moveable.length) {
@@ -147,7 +147,7 @@ Move Allocation
           }
         },
         error: function (data) {
-          $('#id_new_project_info').html(
+          $('#id_destination_project_info').html(
             `<div class="alert alert-danger m-0">
               <i class="fa fa-info-circle" aria-hidden="true"></i> An error has occured.
             </div>`
@@ -155,7 +155,7 @@ Move Allocation
         }
       })
     })
-    $('#id_new_project_info')
+    $('#id_destination_project_info')
   })
 </script>
 

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
@@ -107,7 +107,10 @@ Move Allocation
           <div id="id_destination_project_info"></div>
         </div>
         <div class="card-footer">
-          <button id="id_submit" class="btn btn-primary float-right confirm-move" type="submit">
+          <a href="{% url 'allocation-detail' allocation.pk %}" class="btn btn-secondary float-right">
+            Cancel
+          </a>
+          <button id="id_submit" class="btn btn-primary float-right confirm-move mr-1" type="submit">
             <i class="fas fa-angle-double-right"></i>  Move Into
           </button>
         </div>

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
@@ -103,7 +103,7 @@ Move Allocation
           <div id="id_new_project_info"></div>
         </div>
         <div class="card-footer">
-          <button id="id_submit" class="btn btn-primary float-right" type="submit">Move Into</button>
+          <button id="id_submit" class="btn btn-primary float-right confirm-move" type="submit">Move Into</button>
         </div>
       </div>
     </div>
@@ -111,6 +111,9 @@ Move Allocation
 </form>
 
 <script>
+  $(document).on('click', '.confirm-move', function () {
+    return confirm('Are you sure you want to move this allocation? All of the users in this allocation will be added to the destination project if they do not exist already.');
+  })
   $(document).ready(function () {
     $('#id_new_project').addClass('form-control')
     $('#id_new_project').change(function (e) {

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
@@ -10,17 +10,16 @@ Move Allocation
 
 
 {% block content %}
-<h2>Move Allocation to a Different Project</h2>
+<h2>Move {{ allocation.get_parent_resource.name }} Allocation to a Different Project</h2>
 <hr>
 
 <p>
-  You can move an allocation from this project to another you own as long as the other project does
-  not reach any limits, i.e. the maximum allowed for this resource the project can have. NOTE: Users
-  will also be moved over within the allocation. Any users missing from the project will
-  automatically be added to it. If there are users you do not want included in the move then remove
-  them from the allocation first. If this is a compute allocation then when you move it over to the
-  other project you will be given a new slurm account to use. For storage allocations this will not
-  affect how you access your storage.
+  You can move an allocation from this project to another you own as long as the other project's
+  restrictions are not met, i.e. max allocations allowed for this resource in the project. <strong>
+  Users in the allocation are also moved over and anyone missing from the destination project are
+  automatically added to it. If there are users you do not want included in the move then remove
+  them from the allocation first.</strong> Compute allocations being moved will be given a new slurm
+  account. Storage allocation file system access will not be effected.
 </p>
 
 <form action="{% url 'move-allocation' allocation.pk %}" method="post">

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
@@ -1,0 +1,150 @@
+{% extends "common/base.html" %}
+{% load crispy_forms_tags %}
+{% load common_tags %}
+{% load static %}
+
+
+{% block title %}
+Move Allocation
+{% endblock %}
+
+
+{% block content %}
+<h2>Move Allocation to a Different Project</h2>
+<hr>
+
+<p>
+  You can move an allocation from this project to another you own as long as the other project does
+  not reach any limits, i.e. the maximum allowed for this resource the project can have. NOTE: Users
+  will also be moved over within the allocation. Any users missing from the project will
+  automatically be added to it. If there are users you do not want included in the move then remove
+  them from the allocation first. If this is a compute allocation then when you move it over to the
+  other project you will be given a new slurm account to use. For storage allocations this will not
+  affect how you access your storage.
+</p>
+
+<form action="{% url 'move-allocation' allocation.pk %}" method="post">
+  {% csrf_token %}
+  <div class="row">
+    <div class="col">
+      <div class="card">
+        <div class="card-header">
+          <h3>Current Project</h3>
+        </div>
+        <div class="card-body">
+          <fieldset>
+            <legend><strong><u>Project Info</u></strong></legend>
+            <p><strong>Title:</strong> {{ allocation.project.title }}</p>
+            <p><strong>Project Description:</strong> {{ allocation.project.description }}</p>
+            <p><strong>Project Type:</strong> {{ allocation.project.type }}</p>
+            <p><strong>End Date:</strong> {{ allocation.project.end_date }}</p>
+          </fieldset>
+          <hr>
+          <fieldset>
+            <legend><strong><u>Allocation Info</u></strong></legend>
+            <p><strong>Resource:</strong> {{ allocation.get_parent_resource.name }}</p>
+            <p><strong>End Date:</strong> {{ allocation.end_date }}</p>
+            <div>
+              <strong>Users:</strong>
+              <ul>
+                {% for user in allocation_users %}
+                <li>{{ user.user.first_name }}, {{ user.user.last_name}} ({{ user.user.username }})</li>
+                {% endfor %}
+              </ul>
+            </div>
+            <div class="card">
+              <div class="card-header">
+                <h4>Attributes</h4>
+              </div>
+              <div class="card-body">
+                <div class="table-responsive">
+                  <table class="table table-bordered table-sm">
+                    <thead>
+                      <tr>
+                        <th scope="col">Attribute</th>
+                        <th scope="col">Value</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {% for attribute in allocation_attributes %}
+                      <tr>
+                        <td>{{attribute}}</td>
+                        <td>{{attribute.value}}</td>
+                      </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+    <div style="display: flex; align-items: center;">
+      <i class="fas fa-angle-double-right"></i>
+    </div>
+    <div class="col">
+      <div class="card">
+        <div class="card-header">
+          <div class="row">
+            <div class="col">
+              <label for="id_new_project">
+                <h3 class="m-0">{{ form.new_project.label|title }}</h3>
+              </label>
+            </div>
+            <div class="col">
+              {{ form.new_project }}
+            </div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div id="id_new_project_info"></div>
+        </div>
+        <div class="card-footer">
+          <button id="id_submit" class="btn btn-primary float-right" type="submit">Move Into</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+
+<script>
+  $(document).ready(function () {
+    $('#id_new_project').addClass('form-control')
+    $('#id_new_project').change(function (e) {
+      var project_pk = $("#id_new_project option:selected").val();
+      if (!project_pk) {
+        $('#id_new_project_info').html('')
+        return;
+      }
+
+      $('#id_new_project_info').html(
+        '<i class="fas fa-sync fa-spin fa-fw" aria-hidden="true"></i> Grabbing project information...'
+      );
+      $.ajax({
+        url: `project-info/${project_pk}`,
+        success: function (data) {
+          $('#id_new_project_info').html(data)
+          var not_moveable = $('#id_not_moveable');
+          console.log(not_moveable.length);
+          if (not_moveable.length) {
+            $('#id_submit').prop('disabled', true)
+          } else {
+            $('#id_submit').prop('disabled', false)
+          }
+        },
+        error: function (data) {
+          $('#id_new_project_info').html(
+            `<div class="alert alert-danger m-0">
+              <i class="fa fa-info-circle" aria-hidden="true"></i> An error has occured.
+            </div>`
+          )
+        }
+      })
+    })
+    $('#id_new_project_info')
+  })
+</script>
+
+{% endblock %}

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/allocation_move.html
@@ -103,7 +103,9 @@ Move Allocation
           <div id="id_new_project_info"></div>
         </div>
         <div class="card-footer">
-          <button id="id_submit" class="btn btn-primary float-right confirm-move" type="submit">Move Into</button>
+          <button id="id_submit" class="btn btn-primary float-right confirm-move" type="submit">
+            <i class="fas fa-angle-double-right"></i>  Move Into
+          </button>
         </div>
       </div>
     </div>
@@ -112,7 +114,14 @@ Move Allocation
 
 <script>
   $(document).on('click', '.confirm-move', function () {
-    return confirm('Are you sure you want to move this allocation? All of the users in this allocation will be added to the destination project if they do not exist already.');
+    var confirmation = confirm('Are you sure you want to move this allocation? All of the users in this allocation will be added to the destination project if they do not exist already.');
+    if (!confirmation) {
+      return confirmation
+    }
+    $('#id_submit').html(
+      '<i class="fas fa-sync fa-spin fa-fw" aria-hidden="true"></i> Moving allocation...'
+    );
+    return confirmation
   })
   $(document).ready(function () {
     $('#id_new_project').addClass('form-control')

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/email/moved_allocation.txt
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/email/moved_allocation.txt
@@ -1,0 +1,13 @@
+Your {{ resource }} allocation, {{ allocation_url }}, was moved to a different project by
+{{ user.first_name }} {{ user.last_name }} ({{ user.username }}).
+
+New location:
+Project: {{ destination_project_url }}
+
+Old location:
+Project: {{ origin_project_url }}
+
+If this allocation has a compute resource then its slurm account has changed. You should
+visit your allocation and note the new slurm account.
+
+{{ signature }}

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/email/moved_allocation_admin.txt
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/email/moved_allocation_admin.txt
@@ -1,0 +1,8 @@
+A {{ resource }} allocation, {{ allocation_url }}, was moved to a different project by
+{{ user.first_name }} {{ user.last_name }} ({{ user.username }}).
+
+New location:
+Project: {{ destination_project_url }}
+
+Old location:
+Project: {{ origin_project_url }}

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/project_detail.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/project_detail.html
@@ -10,7 +10,12 @@
   </div>
 {% endif %}
 <fieldset>
-  <legend><strong><u>Project Info</u></strong></legend>
+  <legend>
+    <strong><u>Project Info</u></strong>
+    <a href="{% url 'project-detail' project.pk %}" target="_blank">
+      <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+    </a>
+  </legend>
   <p><strong>ID:</strong> {{ project.pk }}</p>
   <p><strong>Title:</strong> {{ project.title }}</p>
   <p><strong>Project Description:</strong> {{ project.description }}</p>

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/project_detail.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/project_detail.html
@@ -11,6 +11,7 @@
 {% endif %}
 <fieldset>
   <legend><strong><u>Project Info</u></strong></legend>
+  <p><strong>ID:</strong> {{ project.pk }}</p>
   <p><strong>Title:</strong> {{ project.title }}</p>
   <p><strong>Project Description:</strong> {{ project.description }}</p>
   <p><strong>Project Type:</strong> {{ project.type }}</p>

--- a/coldfront/plugins/movable_allocations/templates/movable_allocations/project_detail.html
+++ b/coldfront/plugins/movable_allocations/templates/movable_allocations/project_detail.html
@@ -1,0 +1,57 @@
+{% if over_allocation_limit %}
+  <div id="id_not_moveable" class="alert alert-danger">
+    <i class="fa fa-info-circle"></i>
+    Moving this allocation to this project will put it over its resource limit.
+  </div>
+{% elif not resource_allowed %}
+  <div id="id_not_moveable" class="alert alert-danger">
+    <i class="fa fa-info-circle"></i>
+    The resource in this allocation is not allowed in this type of project.
+  </div>
+{% endif %}
+<fieldset>
+  <legend><strong><u>Project Info</u></strong></legend>
+  <p><strong>Title:</strong> {{ project.title }}</p>
+  <p><strong>Project Description:</strong> {{ project.description }}</p>
+  <p><strong>Project Type:</strong> {{ project.type }}</p>
+  <p><strong>End Date:</strong> {{ project.end_date }}</p>
+</fieldset>
+<div class="card">
+  <div class="card-header">
+    <h4>Allocations</h4>
+  </div>
+  <div class="card-body">
+    {% if allocations %}
+      <div class="table-responsive">
+        <table class="table table-bordered table-sm">
+          <thead>
+            <tr>
+              <th scope="col">Resource</th>
+              <th scope="col">Information</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for allocation in allocations %}
+              <tr>
+                <td>
+                  <a class="text-nowrap" href="{% url 'allocation-detail' allocation.pk %}" target="_blank">
+                    {{ allocation.get_parent_resource.name }}
+                  </a>
+                </td>
+                {% if allocation.get_information != '' %}
+                  <td class="text-nowrap">{{ allocation.get_information }}</td>
+                {% else %}
+                  <td class="text-nowrap">{{allocation.description|default_if_none:""}}</td>
+                {% endif %}
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      <div class="alert alert-info">
+        <i class="fa fa-info-circle"></i> This project has no active allocations.
+      </div>
+    {% endif %}
+  </div>
+</div>

--- a/coldfront/plugins/movable_allocations/tests.py
+++ b/coldfront/plugins/movable_allocations/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/coldfront/plugins/movable_allocations/urls.py
+++ b/coldfront/plugins/movable_allocations/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from coldfront.plugins.movable_allocations.views import (
+    AllocationMoveView,
+    ProjectDetailView,
+)
+
+urlpatterns = [
+    path("<int:pk>/move-allocation", AllocationMoveView.as_view(), name="move-allocation"),
+    path("<int:pk>/project-info/<int:project_pk>", ProjectDetailView.as_view(), name="project-info"),
+]

--- a/coldfront/plugins/movable_allocations/utils.py
+++ b/coldfront/plugins/movable_allocations/utils.py
@@ -1,0 +1,14 @@
+def check_over_allocation_limit(allocation_obj_moving, allocation_objs):
+        resource = allocation_obj_moving.get_parent_resource
+        limit_obj = resource.resourceattribute_set.filter(
+            resource_attribute_type__name="allocation_limit"
+        ).first()
+        if not limit_obj:
+            return False
+
+        return int(limit_obj.value) < allocation_objs.filter(resources=resource).count() + 1
+
+def check_resource_is_allowed(allocation_obj_moving, project_obj):
+    forbidden_resources = project_obj.get_env.get("forbidden_resources")
+    resource = allocation_obj_moving.get_parent_resource.name
+    return resource not in forbidden_resources

--- a/coldfront/plugins/movable_allocations/views.py
+++ b/coldfront/plugins/movable_allocations/views.py
@@ -113,7 +113,7 @@ class AllocationMoveView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
                 messages.error(request, error)
             return HttpResponseRedirect(reverse("move-allocation", kwargs={"pk": pk}))
 
-        destination_project_obj = form.cleaned_data.get("new_project")
+        destination_project_obj = form.cleaned_data.get("destination_project")
         if check_over_allocation_limit(
             allocation_obj,
             destination_project_obj.allocation_set.filter(

--- a/coldfront/plugins/movable_allocations/views.py
+++ b/coldfront/plugins/movable_allocations/views.py
@@ -248,6 +248,8 @@ class AllocationMoveView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
             f"{origin_project_obj.pk} to project {destination_project_obj.pk}"
         )
 
+        messages.success(request, "Your allocation was successfully moved.")
+
         return HttpResponseRedirect(reverse("allocation-detail", kwargs={"pk": pk}))
 
 

--- a/coldfront/plugins/movable_allocations/views.py
+++ b/coldfront/plugins/movable_allocations/views.py
@@ -1,0 +1,268 @@
+import logging
+
+from django.contrib import messages
+from django.contrib.auth.models import User
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.http import HttpResponseNotFound, HttpResponseRedirect
+from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
+from django.views.generic import TemplateView
+
+from coldfront.core.allocation.utils import create_admin_action
+from coldfront.core.utils.common import get_domain_url
+from coldfront.core.utils.mail import send_allocation_customer_email, send_allocation_admin_email
+from coldfront.core.utils.groups import check_if_groups_in_review_groups
+from coldfront.core.allocation.models import Allocation, AllocationUserNote
+from coldfront.core.project.models import (
+    Project,
+    ProjectUser,
+    ProjectUserRoleChoice,
+    ProjectUserStatusChoice,
+    ProjectUserMessage,
+)
+from coldfront.plugins.movable_allocations.forms import AllocationMoveForm
+from coldfront.plugins.movable_allocations.utils import (
+    check_over_allocation_limit,
+    check_resource_is_allowed,
+)
+from coldfront.plugins.movable_allocations.signals import allocation_moved
+
+logger = logging.getLogger(__name__)
+
+
+class AllocationMoveView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
+    template_name = "movable_allocations/allocation_move.html"
+
+    def test_func(self):
+        allocation_obj = get_object_or_404(Allocation, pk=self.kwargs.get("pk"))
+        if self.request.user.is_superuser:
+            return True
+
+        group_exists = check_if_groups_in_review_groups(
+            allocation_obj.get_parent_resource.review_groups.all(),
+            self.request.user.groups.all(),
+            "change_allocation",
+        )
+        if group_exists:
+            return True
+
+        # if self.request.user == allocation_obj.project.pi:
+        #     return True
+
+        messages.error(self.request, "You do not have permission to move this allocation.")
+        return False
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_superuser:
+            return super().dispatch(request, *args, **kwargs)
+
+        allocation_obj = get_object_or_404(Allocation, pk=kwargs.get("pk"))
+        if not allocation_obj.status.name == "Active":
+            messages.error(request, "You cannot move an inactive allocation.")
+            return HttpResponseRedirect(
+                reverse("allocation-detail", kwargs={"pk": kwargs.get("pk")})
+            )
+
+        if not allocation_obj.project.status.name == "Active":
+            messages.error(request, "You cannot move an allocation in an inactive project.")
+            return HttpResponseRedirect(
+                reverse("allocation-detail", kwargs={"pk": kwargs.get("pk")})
+            )
+
+        is_moveable = allocation_obj.allocationattribute_set.filter(
+            allocation_attribute_type__name="Is Moveable"
+        ).first()
+        if is_moveable and is_moveable.value == "Yes":
+            messages.error(request, "Allocation must be moveable.")
+            return HttpResponseRedirect(
+                reverse("allocation-detail", kwargs={"pk": kwargs.get("pk")})
+            )
+
+        if allocation_obj.is_locked:
+            messages.error(request, "You cannot move a locked allocation")
+            return HttpResponseRedirect(
+                reverse("allocation-detail", kwargs={"pk": kwargs.get("pk")})
+            )
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        pk = self.kwargs.get("pk")
+        allocation_obj = get_object_or_404(Allocation, pk=pk)
+        form = AllocationMoveForm(allocation_obj.project.pi, allocation_obj.project.pk)
+        context = self.get_context_data()
+        context["form"] = form
+        context["allocation"] = allocation_obj
+        context["allocation_users"] = allocation_obj.allocationuser_set.filter(
+            status__name="Active"
+        )
+        context["allocation_attributes"] = allocation_obj.allocationattribute_set.filter(
+            allocation_attribute_type__is_private=False
+        )
+        return self.render_to_response(context)
+
+    def post(self, request, *args, **kwargs):
+        pk = self.kwargs.get("pk")
+        allocation_obj = get_object_or_404(Allocation, pk=pk)
+        origin_project_obj = allocation_obj.project
+
+        form = AllocationMoveForm(request.user, origin_project_obj.pk, request.POST)
+        if not form.is_valid():
+            for error in form.errors:
+                messages.error(request, error)
+            return HttpResponseRedirect(reverse("move-allocation", kwargs={"pk": pk}))
+
+        destination_project_obj = form.cleaned_data.get("new_project")
+        if check_over_allocation_limit(
+            allocation_obj,
+            destination_project_obj.allocation_set.filter(
+                status__name="Active", resources=allocation_obj.get_parent_resource
+            ),
+        ):
+            messages.error(
+                request,
+                "Moving this allocation to this project will put it over its resource limit.",
+            )
+            return HttpResponseRedirect(reverse("move-allocation", kwargs={"pk": pk}))
+
+        if not check_resource_is_allowed(allocation_obj, destination_project_obj):
+            messages.error(
+                request, "The resource in this allocation is not allowed in this type of project."
+            )
+            return HttpResponseRedirect(reverse("move-allocation", kwargs={"pk": pk}))
+
+        if not request.user == origin_project_obj.pi:
+            create_admin_action(
+                user=request.user,
+                fields_to_check={"project": destination_project_obj},
+                allocation=allocation_obj,
+            )
+
+        allocation_obj.project = destination_project_obj
+        allocation_obj.save()
+
+        project_user_active_status = ProjectUserStatusChoice.objects.get(name="Active")
+        project_users_removed_status = ProjectUserStatusChoice.objects.get(name="Removed")
+        auto_disable = allocation_obj.project.projectattribute_set.filter(
+            proj_attr_type__name="Auto Disable User Notifications"
+        ).first()
+        enable_notifications = not (auto_disable and auto_disable.value == "Yes")
+        for allocation_user in allocation_obj.allocationuser_set.all():
+            project_user_obj = destination_project_obj.projectuser_set.filter(
+                user=allocation_user.user
+            ).first()
+            if project_user_obj:
+                if not project_user_obj.status.name == "Active":
+                    if allocation_user.status.name in ["Active", "Invited", "Disabled", "Retired"]:
+                        project_user_obj.status = project_user_active_status
+                        project_user_obj.save()
+            else:
+                project_user = origin_project_obj.projectuser_set.get(user=allocation_user.user)
+                role = "Group" if project_user.role.name == "Group" else "User"
+                status = project_user_active_status
+                if allocation_user.status.name not in ["Active", "Invited", "Disabled", "Retired"]:
+                    status = project_users_removed_status
+                project_user_obj = ProjectUser.objects.create(
+                    user=allocation_user.user,
+                    project=destination_project_obj,
+                    role=ProjectUserRoleChoice.objects.get(name=role),
+                    status=status,
+                    enable_notifications=enable_notifications,
+                )
+
+        domain_url = get_domain_url(request)
+        destination_project_url = (
+            f"{domain_url}{reverse('project-detail', kwargs={'pk': destination_project_obj.pk})}"
+        )
+        origin_project_url = (
+            f"{domain_url}{reverse('project-detail', kwargs={'pk': origin_project_obj.pk})}"
+        )
+        allocation_url = (
+            f"{domain_url}{reverse('allocation-detail', kwargs={'pk': allocation_obj.pk})}"
+        )
+        AllocationUserNote.objects.create(
+            allocation=allocation_obj,
+            author=User.objects.get(username="coldft"),
+            is_private=False,
+            note=f"{request.user.first_name} {request.user.last_name} ({request.user.username}) "
+            f'moved this allocation from project "{origin_project_obj.title}", {origin_project_url}'
+            f', to project "{destination_project_obj.title}", {destination_project_url}.',
+        )
+
+        ProjectUserMessage.objects.create(
+            project=origin_project_obj,
+            author=User.objects.get(username="coldft"),
+            is_private=False,
+            message=f"{request.user.first_name} {request.user.last_name} ({request.user.username}) "
+            f"moved a {allocation_obj.get_parent_resource} allocation, {allocation_url}, from this "
+            f'project to project "{destination_project_obj.title}", {destination_project_url}.',
+        )
+
+        ProjectUserMessage.objects.create(
+            project=destination_project_obj,
+            author=User.objects.get(username="coldft"),
+            is_private=False,
+            message=f"{request.user.first_name} {request.user.last_name} ({request.user.username}) "
+            f"moved a {allocation_obj.get_parent_resource} allocation, {allocation_url}, from project "
+            f'"{origin_project_obj.title}", {origin_project_url}, to this project.',
+        )
+
+        addtl_context = {
+            "user": self.request.user,
+            "resource": allocation_obj.get_parent_resource,
+            "destination_project_url": destination_project_url,
+            "origin_project_url": origin_project_url,
+            "allocation_url": allocation_url,
+        }
+        send_allocation_customer_email(
+            allocation_obj,
+            "Allocation Moved",
+            "movable_allocations/email/moved_allocation.txt",
+            addtl_context=addtl_context,
+        )
+        send_allocation_admin_email(
+            allocation_obj,
+            "Allocation Moved",
+            "movable_allocations/email/moved_allocation_admin.txt",
+            addtl_context=addtl_context,
+        )
+
+        allocation_moved.send(
+            sender=self.__class__,
+            allocation_pk=allocation_obj.pk,
+            origin_project_pk=origin_project_obj.pk,
+            destination_project_pk=destination_project_obj.pk,
+        )
+
+        role = "Admin" if not request.user == origin_project_obj.pi else "User"
+        logger.info(
+            f"{role} {request.user.username} moved allocation {allocation_obj.pk} from project "
+            f"{origin_project_obj.pk} to project {destination_project_obj.pk}"
+        )
+
+        return HttpResponseRedirect(reverse("allocation-detail", kwargs={"pk": pk}))
+
+
+class ProjectDetailView(LoginRequiredMixin, TemplateView):
+    template_name = "movable_allocations/project_detail.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.META.get("HTTP_REFERER") is None:
+            return HttpResponseNotFound(render(request, "404.html", {}))
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        project_pk = self.kwargs.get("project_pk")
+        allocation_pk = self.kwargs.get("pk")
+        project_obj = get_object_or_404(Project, pk=project_pk)
+        allocation_obj = get_object_or_404(Allocation, pk=allocation_pk)
+        context = self.get_context_data()
+        context["project"] = project_obj
+        allocation_objs = project_obj.allocation_set.filter(status__name="Active")
+        context["allocations"] = allocation_objs
+        context["over_allocation_limit"] = check_over_allocation_limit(
+            allocation_obj, allocation_objs
+        )
+        context["resource_allowed"] = check_resource_is_allowed(allocation_obj, project_obj)
+
+        return self.render_to_response(context)

--- a/coldfront/plugins/movable_allocations/views.py
+++ b/coldfront/plugins/movable_allocations/views.py
@@ -9,10 +9,11 @@ from django.urls import reverse
 from django.views.generic import TemplateView
 
 from coldfront.core.allocation.utils import create_admin_action
+from coldfront.core.project.utils import generate_slurm_account_name
 from coldfront.core.utils.common import get_domain_url
 from coldfront.core.utils.mail import send_allocation_customer_email, send_allocation_admin_email
 from coldfront.core.utils.groups import check_if_groups_in_review_groups
-from coldfront.core.allocation.models import Allocation, AllocationUserNote
+from coldfront.core.allocation.models import Allocation, AllocationAttribute, AllocationUserNote
 from coldfront.core.project.models import (
     Project,
     ProjectUser,
@@ -140,6 +141,13 @@ class AllocationMoveView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
 
         allocation_obj.project = destination_project_obj
         allocation_obj.save()
+
+        slurm_account_obj = AllocationAttribute.objects.filter(
+            allocation_attribute_type__name="slurm_account_name"
+        ).first()
+        if slurm_account_obj:
+            slurm_account_obj.value = generate_slurm_account_name(allocation_obj.project)
+            slurm_account_obj.save()
 
         project_user_active_status = ProjectUserStatusChoice.objects.get(name="Active")
         project_users_removed_status = ProjectUserStatusChoice.objects.get(name="Removed")


### PR DESCRIPTION
This plugin adds the ability for admins to move an allocation from one project to another. Users in the allocation will automatically be added to the new project if they aren't in it already.