### PR TITLE
Help request form

### DIFF
--- a/coldfront/config/plugins/help.py
+++ b/coldfront/config/plugins/help.py
@@ -1,0 +1,5 @@
+from coldfront.config.base import INSTALLED_APPS
+
+INSTALLED_APPS += [
+    'coldfront.plugins.help',
+]

--- a/coldfront/config/plugins/help.py
+++ b/coldfront/config/plugins/help.py
@@ -1,5 +1,12 @@
 from coldfront.config.base import INSTALLED_APPS
+from coldfront.config.env import ENV
+from coldfront.core.utils.common import import_from_settings
 
 INSTALLED_APPS += [
     'coldfront.plugins.help',
 ]
+
+SUPPORT_EMAILS = sorted(import_from_settings('SUPPORT_EMAILS', []), key=lambda x: x["title"])
+EMAIL_HELP_TEMPLATE = ENV.str("EMAIL_HELP_TEMPLATE")
+EMAIL_HELP_DEFAULT_TARGET = ENV.str("EMAIL_HELP_DEFAULT_TARGET")
+

--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -34,7 +34,8 @@ plugin_configs = {
     'PLUGIN_PI_SEARCH': 'plugins/pi_search.py',
     'PLUGIN_ALLOCATION_REMOVAL_REQUESTS':'plugins/allocation_removal_requests.py',
     'PLUGIN_ANNOUNCEMENTS': 'plugins/announcements.py',
-    'PLUGIN_MOVABLE_ALLOCATIONS': 'plugins/movable_allocations.py'
+    'PLUGIN_MOVABLE_ALLOCATIONS': 'plugins/movable_allocations.py',
+    'PLUGIN_HELP': 'plugins/help.py'
 }
 
 # This allows plugins to be enabled via environment variables. Can alternatively

--- a/coldfront/config/urls.py
+++ b/coldfront/config/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path('project/', include('coldfront.core.project.urls')),
     path('allocation/', include('coldfront.core.allocation.urls')),
     path('resource/', include('coldfront.core.resource.urls')),
+    path('help/', include('coldfront.plugins.help.urls')),
 ]
 
 if settings.GRANT_ENABLE:

--- a/coldfront/config/urls.py
+++ b/coldfront/config/urls.py
@@ -21,8 +21,7 @@ urlpatterns = [
     path('user/', include('coldfront.core.user.urls')),
     path('project/', include('coldfront.core.project.urls')),
     path('allocation/', include('coldfront.core.allocation.urls')),
-    path('resource/', include('coldfront.core.resource.urls')),
-    path('help/', include('coldfront.plugins.help.urls')),
+    path('resource/', include('coldfront.core.resource.urls'))
 ]
 
 if settings.GRANT_ENABLE:
@@ -66,6 +65,9 @@ if 'coldfront.plugins.iquota' in settings.INSTALLED_APPS:
 
 if 'mozilla_django_oidc' in settings.INSTALLED_APPS:
     urlpatterns.append(path('oidc/', include('mozilla_django_oidc.urls')))
+
+if 'coldfront.plugins.help' in settings.INSTALLED_APPS:
+    urlpatterns.append(path('help/', include('coldfront.plugins.help.urls'))),
 
 if 'django_su.backends.SuBackend' in settings.AUTHENTICATION_BACKENDS:
     urlpatterns.append(path('su/', include('django_su.urls')))

--- a/coldfront/plugins/help/templates/help/form_completed.html
+++ b/coldfront/plugins/help/templates/help/form_completed.html
@@ -1,0 +1,20 @@
+{% extends "common/base.html" %}
+{% load common_tags %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+
+{% block title %}
+Contact Research Technologies
+{% endblock %}
+
+{% block header %}
+{% endblock %}
+
+{% block content %}
+
+<div class="alert alert-success" role="alert">
+    Your message has been sent. Expect a response within one business day.
+</div>
+
+{% endblock %}

--- a/coldfront/plugins/help/templates/help/help.html
+++ b/coldfront/plugins/help/templates/help/help.html
@@ -1,0 +1,66 @@
+{% extends "common/base.html" %}
+{% load common_tags %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+
+{% block title %}
+Contact Research Technologies
+{% endblock %}
+
+{% block header %}
+{% endblock %}
+
+{% block content %}
+
+<form method="post" action="{% url 'send_help_email' %}">
+    {% csrf_token %}
+    {{ form|crispy }}
+    <div class="form-group">
+        <label for="category">Choose an area to direct your question to: <span class="asteriskField">*</span></label>
+        <select id="category" name="category" class="form-control" required>
+            <option value="" selected="selected"></option>
+            {% for title in titles %}
+                <option value="{{ forloop.counter0 }}">{{ title }}</option>
+            {% endfor %}
+            <option value="{{ -1 }}">Other</option>
+        </select>
+    </div>
+
+    {% if request_user_info %}
+        <div>Name</div>
+        <span class="simple_name_1" style="width: 20%; padding-right: 15px;">
+            <input id="element_1_1" name="element_1_1" aria-required="true" type="text" class="element text " maxlength="255" size="12" value="" required="" aria-invalid="false">
+        </span>
+        <span class="simple_name_2">
+            <input id="element_1_2" name="element_1_2" type="text" class="element text " maxlength="255" size="18" value="" aria-required="true" required="" aria-invalid="false">
+        </span>
+        <br />
+        <label for="element_1_1" style="width: 140px">First<span class="asteriskField">*</span></label>
+        <label for="element_1_2">Last<span class="asteriskField">*</span></label>
+
+        <div class="form-group">
+            <label for="email">Email<span class="asteriskField">*</span></label>
+            <input type="text" id="email" name="email" class="form-control" required>
+        </div>
+    {% endif %}
+    <div class="form-group">
+        <label for="subject">Subject<span class="asteriskField">*</span></label>
+        <input type="text" id="subject" name="subject" class="form-control" required>
+    </div>
+
+    <div class="form-group">
+        <label for="message">Reason for contacting:<span class="asteriskField">*</span></label>
+        <textarea id="message" name="message" class="form-control" rows="5" required></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Send</button>
+</form>
+
+<script>
+    $(document).ready(function () {
+        document.getElementById('category').selectedIndex = {{ selected_index }};
+    });
+</script>
+
+{% endblock %}
+

--- a/coldfront/plugins/help/templates/help/help.html
+++ b/coldfront/plugins/help/templates/help/help.html
@@ -16,16 +16,7 @@ Contact Research Technologies
 <form method="post" action="{% url 'send_help_email' %}">
     {% csrf_token %}
     {{ form|crispy }}
-    <div class="form-group">
-        <label for="category">Choose an area to direct your question to: <span class="asteriskField">*</span></label>
-        <select id="category" name="category" class="form-control" required>
-            <option value="" selected="selected"></option>
-            {% for title in titles %}
-                <option value="{{ forloop.counter0 }}">{{ title }}</option>
-            {% endfor %}
-            <option value="{{ -1 }}">Other</option>
-        </select>
-    </div>
+    <input type="hidden" id="target_index" name="target_index" value="{{ target_index }}">
 
     {% if request_user_info %}
         <div>Name</div>

--- a/coldfront/plugins/help/urls.py
+++ b/coldfront/plugins/help/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from coldfront.plugins.help.views import get_help, send_help, get_targeted_help
+
+urlpatterns = [
+    path('', get_help, name='get-help'),
+    path('<str:tgt>', get_targeted_help, name='get-targeted-help'),
+    path('send', send_help, name='send_help_email'),
+]

--- a/coldfront/plugins/help/urls.py
+++ b/coldfront/plugins/help/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
 from coldfront.plugins.help.views import get_help, send_help, get_targeted_help
+from django.views.decorators.http import require_POST
 
 urlpatterns = [
+    path('send', require_POST(send_help), name='send_help_email'),
     path('', get_help, name='get-help'),
     path('<str:tgt>', get_targeted_help, name='get-targeted-help'),
-    path('send', send_help, name='send_help_email'),
-]
+] 

--- a/coldfront/plugins/help/views.py
+++ b/coldfront/plugins/help/views.py
@@ -1,0 +1,59 @@
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
+from django.http import HttpResponse
+from django.core.mail import send_mail
+from coldfront.core.utils.common import import_from_settings
+from django.contrib.auth.models import User
+from coldfront.config.env import ENV
+
+SUPPORT_EMAILS = sorted(import_from_settings('SUPPORT_EMAILS', []), key=lambda x: x["title"])
+
+
+
+def get_help(request):
+    return get_targeted_help(request, None)
+
+
+def get_targeted_help(request, tgt):
+    context = {}
+    context["titles"] = [e["title"] for e in SUPPORT_EMAILS]
+    sel_index = next((i for i, e in enumerate(SUPPORT_EMAILS) if tgt and e["address"].startswith(tgt)), None)
+    context["selected_index"] = sel_index+1 if sel_index is not None else 0
+    context["request_user_info"] = not request.user.is_authenticated
+
+    return render(request, "help/help.html", context)
+
+
+def send_help(request):
+    form_data = request.POST
+    if form_data:
+        target_id = int(form_data.get("category", -1))
+        if target_id == -1:
+            target_email = "radl@iu.edu"
+        else:
+            target_email = SUPPORT_EMAILS[target_id]["address"]
+
+        if request.user.is_authenticated:
+            user = User.objects.get(username=request.user.username)
+            user_email = user.email
+            first = user.first_name
+            last = user.last_name
+        else:
+            user_email = form_data.get("email", "")
+            first = form_data.get("first_name", "")
+            last = form_data.get("last_name", "")
+
+        message=form_data.get("message", ""),
+
+        email_template = ENV.str("EMAIL_HELP_TEMPLATE")
+
+        send_mail(
+            subject=form_data.get("subject", "Help Request"),
+            message=email_template.format(first=first, last=last, message=message),
+            from_email=user_email,
+            recipient_list=[target_email],
+            fail_silently=False,
+        )
+
+    context = None
+    return render(request, "help/form_completed.html", context)


### PR DESCRIPTION
Supports sending email to the help system. Requests first and last name, and email address unless user is logged in, in which case it takes those from the user. Looks for an extension on the URL to choose where to suggest sending the email, for example

```
https://localhost:8000/help/projects
https://localhost:8000/help/radl
```

I added a set of support emails to local_settings.py and to .env:

```
EMAIL_HELP_TEMPLATE="Name\n{first} {last}\nMessage\n{message}\n"
CENTER_HELP_URL=https://localhost:8000/help/projects 
```

Both of those are in  `/N/project/radl/rtprojects/setup` 

Feel free to make changes or ask me to make them :)