### PR TITLE
Renewal Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ venv/
 static_root/
 db.sqlite3
 local_data/
-site/
 local_settings.py
 local_strings.py
 coldfront.db

--- a/coldfront/components/site/templates/allocation/allocation_detail.html
+++ b/coldfront/components/site/templates/allocation/allocation_detail.html
@@ -218,6 +218,10 @@ Allocation Detail
   </div>
 </div>
 
+{% if allocation.get_parent_resource.name == 'REALLMs API' %}
+  {% include "service/reallms_api/reallms_api_key_div.html" %}
+{% endif %}
+
 {% if attributes or attributes_with_usage or user_has_permissions %}
   <div class="card mb-3">
     <div class="card-header">
@@ -330,10 +334,6 @@ Allocation Detail
       {% endif %}
     </div>
   </div>
-{% endif %}
-
-{% if allocation.get_parent_resource.name == 'REALLMs API' %}
-  {% include "service/reallms_api/reallms_api_key_div.html" %}
 {% endif %}
 
 <!-- Start Allocation Invoices -->

--- a/coldfront/components/site/templates/allocation/allocation_detail.html
+++ b/coldfront/components/site/templates/allocation/allocation_detail.html
@@ -332,8 +332,8 @@ Allocation Detail
   </div>
 {% endif %}
 
-{% if allocation.get_parent_resource.name == 'REALLMs' %}
-  {% include "service/reallms/reallms_api_key_div.html" %}
+{% if allocation.get_parent_resource.name == 'REALLMs API' %}
+  {% include "service/reallms_api/reallms_api_key_div.html" %}
 {% endif %}
 
 <!-- Start Allocation Invoices -->

--- a/coldfront/components/site/templates/email/allocation_expired.txt
+++ b/coldfront/components/site/templates/email/allocation_expired.txt
@@ -17,7 +17,7 @@ Project Type: {{ project_url.3 }}
         {{ resource_name }} - {{ allocation_url }}{% endfor %}{% endfor %}{% endif %}{% endfor %}{% endspaceless %}
 {% endfor %}
 The managers responsible for these projects are required to renew them unless stated otherwise. The expired allocations can be renewed during the project renewal.
-If they are not they will need to be renewed seperately.
+If they are not they will need to be renewed separately.
 For more information about the yearly renewal, visit our knowledge base: {{ project_renewal_help_url }}.
 
 If you are not the PI or a manager under this project, you are receiving this notice as a courtesy.

--- a/coldfront/components/site/templates/email/allocation_expired.txt
+++ b/coldfront/components/site/templates/email/allocation_expired.txt
@@ -1,10 +1,10 @@
 Dear {{center_name}} user,
 
-Your access to {{center_name}} resources has expired. Any accounts under these RT project(s) and allocation(s) are now unable to
+Your access to {{center_name}} resources has expired. Any accounts under these allocation(s) are now unable to
 access the associated resource.
 
 If you wish to continue using them, the managers responsible for the following project(s) must renew the expired
-project(s) and allocation(s) before 7/31, after which the projects will be terminated and cannot be renewed.
+allocations(s) before 7/31, after which the allocations will be terminated and cannot be renewed.
 
 Below is a list of links to your project(s) containing at least one expired allocation: 
 {% for project_key, project_url in project_dict.items %}
@@ -12,12 +12,10 @@ Project Title: {{project_key}}
 Project URL: {{ project_url.0 }}
 Project PI: {{ project_url.1 }} 
 Project Type: {{ project_url.3 }}
-{% if not project_url.2 %}NOTE: This project cannot be renewed. The PI of this project will need to submit a new project.{% endif %}
     {% spaceless %} {% for allocation_key, allocation_value in allocation_dict.items %}{% if allocation_key == project_url.0 %}Expired Allocation(s):{% for allocation in allocation_value %}{% for allocation_url, resource_name in allocation.items %}
         {{ resource_name }} - {{ allocation_url }}{% endfor %}{% endfor %}{% endif %}{% endfor %}{% endspaceless %}
 {% endfor %}
-The managers responsible for these projects are required to renew them unless stated otherwise. The expired allocations can be renewed during the project renewal.
-If they are not they will need to be renewed separately.
+The managers in these projects can renew the allocations. If they are not needed anymore you can safely ignore this email.
 For more information about the yearly renewal, visit our knowledge base: {{ project_renewal_help_url }}.
 
 If you are not the PI or a manager under this project, you are receiving this notice as a courtesy.

--- a/coldfront/components/site/templates/email/allocation_expiring.txt
+++ b/coldfront/components/site/templates/email/allocation_expiring.txt
@@ -1,8 +1,8 @@
 Dear {{center_name}} user,
 
 Your access to Research Technologies resources is expiring soon. To renew, login to RT Projects and
-complete the short renewal process for each expiring project. Failure to renew the expiring RT project(s)
-and its allocation(s) on time will terminate access to the resource for all users in the allocation(s).
+complete the short renewal process for each expiring allocation. Failure to renew the expiring allocation(s)
+will terminate access to the resource for all users in them
 
 Below is a list of links to your project(s) containing at least one expiring allocation:
 {% for project_key, project_url in project_dict.items %}
@@ -10,17 +10,13 @@ Project Title: {{project_key}}
 Project URL: {{ project_url.0 }}
 Project PI: {{ project_url.1 }}
 Project Type: {{ project_url.3 }}
-{% if not project_url.2 %}NOTE: This project cannot be renewed. The PI of this project will need to submit a new project.{% endif %}
     {% spaceless %}{% for days_key, days_value in expiration_dict.items %}
     Allocation(s) expiring in {{days_key}} days:{% for allocations in days_value %}{% if allocations.0 == project_url.0 %}  
         {% spaceless %}{{ allocations.2 }}{% endspaceless %}{% endif %}{% endfor %}
         {% endfor %}{% endspaceless %}
 {% endfor %}
-The managers for these projects are required to renew them unless stated otherwise. The expiring allocations can be renewed during the project renewal.
-If they are not they will need to be renewed separately. If you do not need any of these projects anymore we recommend archiving them, doing so will
-expire all allocations with it. You can do so with the archive project button on your project's detail page. You will not receive renewal emails
-for archived projects. Archiving a project does not affect any of the data within the resource allocations it has.
-For more information about the yearly renewal, visit our knowledge base: {{ project_renewal_help_url }}
+The managers in these projects can renew the allocations. If they are not needed anymore you can safely ignore this email.
+For more information about the yearly renewal, visit our knowledge base: {{ project_renewal_help_url|safe }}
 
 If you are not the PI or a manager under this project, you are receiving this notice as a courtesy.
 

--- a/coldfront/components/site/templates/email/allocation_expiring.txt
+++ b/coldfront/components/site/templates/email/allocation_expiring.txt
@@ -17,7 +17,7 @@ Project Type: {{ project_url.3 }}
         {% endfor %}{% endspaceless %}
 {% endfor %}
 The managers for these projects are required to renew them unless stated otherwise. The expiring allocations can be renewed during the project renewal.
-If they are not they will need to be renewed seperately. If you do not need any of these projects anymore we recommend archiving them, doing so will
+If they are not they will need to be renewed separately. If you do not need any of these projects anymore we recommend archiving them, doing so will
 expire all allocations with it. You can do so with the archive project button on your project's detail page. You will not receive renewal emails
 for archived projects. Archiving a project does not affect any of the data within the resource allocations it has.
 For more information about the yearly renewal, visit our knowledge base: {{ project_renewal_help_url }}

--- a/coldfront/components/site/templates/email/project_expired.txt
+++ b/coldfront/components/site/templates/email/project_expired.txt
@@ -1,0 +1,36 @@
+Dear {{center_name}} user,
+
+Your access to {{center_name}} resources has expired. Any accounts under these RT project(s) and
+allocation(s) are now unable to access the associated resource.
+
+If you wish to continue using them, the managers responsible for the following project(s) must renew the expired
+project(s) and allocation(s) before 7/31, after which the projects will be terminated and cannot be renewed.
+
+Below is your expired project(s):
+{% spaceless %}
+{% for project in project_dict %}
+----------------------------------------------
+Project Title: {{project.project.title}}
+Project URL: {{ project.project_url }}
+Project PI: {{ project.project.pi }}
+Project Type: {{ project.project.type }}
+{% if project.project.type.name == 'Class' %}
+NOTE: This project cannot be renewed. The PI of this project will need to submit a new project.
+{% endif %}
+Allocations expired:
+{% for allocation in project.allocations %}    {{ allocation.get_parent_resource }}
+{% empty %}    No allocations to list{% endfor %}
+{% endfor %}
+{% endspaceless %}
+
+The managers responsible for these projects are required to renew them unless stated otherwise. The
+expired allocations can be renewed during the project renewal. If they are not they will need to be
+renewed separately.
+For more information about the yearly renewal, visit our knowledge base: {{ project_renewal_help_url|safe }}.
+
+If you are not the PI or a manager under this project, you are receiving this notice as a courtesy.
+
+If you have any questions please email us at {{ help_email }}
+
+Thank you,
+{{ signature }}

--- a/coldfront/components/site/templates/email/project_expiring.txt
+++ b/coldfront/components/site/templates/email/project_expiring.txt
@@ -1,12 +1,34 @@
-Dear {{ center_name }} user,
+Dear {{center_name}} user,
 
-Your project "{{ project_title }}" on RT Projects will expire in {{ expiring_in_days }} day{{ expiring_in_days|pluralize }}.
-This project has no allocations in it and is not providing access to any of RT's resources. Once it expires you will no longer 
-be able to edit your project. If you do not need this project to give you access to RT's resources then it is recommended to
-archive it. You can do so with the archive project button on your project's detail page. Archiving a project will terminate it
-and you will not receive renewal emails. 
+Your access to {{center_name}} resources is expiring soon. To renew, login to RT Projects and
+complete the short renewal process for each expiring project. Failure to renew the expiring RT project(s)
+and its allocation(s) on time will terminate access to the resource for all users in the allocation(s).
 
-If you are not the PI or a manager in this project you are receiving this notice as a courtesy.
+Below is your expiring project(s):
+{% spaceless %}
+{% for project in project_dict %}
+----------------------------------------------
+Project Title: {{project.project.title}}
+Project URL: {{ project.project_url }}
+Project PI: {{ project.project.pi }}
+Project Type: {{ project.project.type }}
+Project Days Remaining: {{ expiring_in_days }}
+{% if project.project.type.name == 'Class' %}
+NOTE: This project cannot be renewed. The PI of this project will need to submit a new project.
+{% endif %}
+Allocations expiring soon:
+{% for allocation in project.allocations %}    {{ allocation.get_parent_resource }}
+{% empty %}    No allocations to list{% endfor %}
+{% endfor %}
+{% endspaceless %}
+
+The managers for these projects are required to renew them unless stated otherwise. The expiring allocations can be renewed during the project renewal.
+If they are not they will need to be renewed separately. If you do not need any of these projects anymore we recommend archiving them, doing so will
+expire all allocations with it. You can do so with the archive project button on your project's detail page. You will not receive renewal emails
+for archived projects. Archiving a project does not affect any of the data within the resource allocations it has.
+For more information about the yearly renewal, visit our knowledge base: {{ project_renewal_help_url|safe }}
+
+If you are not the PI or a manager under this project, you are receiving this notice as a courtesy.
 
 If you have any questions please email us at {{ help_email }}
 

--- a/coldfront/components/site/templates/project/add_user_search_results.html
+++ b/coldfront/components/site/templates/project/add_user_search_results.html
@@ -68,7 +68,7 @@
             <th><input type="checkbox" class="check" id="selectAll"></th>
             <th scope="col">#</th>
             <th scope="col">
-              <a href="#" data-toggle="popover" title="Info" data-trigger="hover" data-content="Hover over an icon to see a user's account status for each selected resource">
+              <a href="#" class="notnavigable" data-toggle="popover" title="Info" data-trigger="hover" data-content="Hover over an icon to see a user's account status for each selected resource">
                 <span class="badge badge-info"><i class="fas fa-question-circle"></i></span><span class="sr-only">Hover over an icon to see a user's account status for each selected resource</span>
               </a>
             </th>
@@ -85,7 +85,7 @@
               <td>{{ form.selected }}</td>
               <td>{{ forloop.counter }}</td>
               <td>
-                <a id="status-{{ forloop.counter }}" href="#" data-toggle="popover" title="No Allocations Selected" data-trigger="hover" data-content="No allocations to check accounts on">
+                <a id="status-{{ forloop.counter }}" class="notnavigable" href="#" data-toggle="popover" title="No Allocations Selected" data-trigger="hover" data-content="No allocations to check accounts on">
                   <span class="badge badge-secondary"><i class="fas fa-minus-circle"></i></span><span class="sr-only">No allocations to check accounts on</span>
                 </a>
               </td>
@@ -274,7 +274,8 @@
   }
 
   $('document').ready(function () {
-    $('[data-toggle="popover"]').popover();  
+    $('[data-toggle="popover"]').popover();
+    $('a.notnavigable').click(function(e) {e.preventDefault();});
     for (var i = 0; i < matches; i++) {
       var username = user_accounts[i][0];
       all_accounts[username] = new Set();

--- a/coldfront/components/site/templates/project/project_review_info.html
+++ b/coldfront/components/site/templates/project/project_review_info.html
@@ -5,7 +5,7 @@
 
 
 {% block title %}
-Test title
+Project Review Info
 {% endblock %}
 
 {% block content %}

--- a/coldfront/components/site/templates/project/project_review_list.html
+++ b/coldfront/components/site/templates/project/project_review_list.html
@@ -84,13 +84,20 @@ Project Review List
             <td>{{ project_review.created|date:"M. d, Y" }}</td>
             <td>{{ project_review.project.end_date|date:"M. d, Y" }}</td>
             <td>
-              <a href="#" data-toggle="modal" data-target="#id_pi_projects_modal" data-pi="{{project_review.project.pi.username}}" data-pk="{{project_review.project.pk}}">
+              <a
+                href="#"
+                data-toggle="modal"
+                data-target="#id_pi_projects_modal"
+                data-pi="{{project_review.project.pi.username}}"
+                data-pk="{{project_review.project.pk}}"
+                data-eligible="{{pi_eligibilities|get_value_from_dict:project_review.project.pi.username}}"
+              \>
                 {{ project_review.project.pi.first_name }} {{ project_review.project.pi.last_name }} ({{ project_review.project.pi.username }})
               </a>
               {% if not pi_eligibilities|get_value_from_dict:project_review.project.pi.username %}
-              <a href="#" class="notnavigable" data-toggle="popover" title="Not Eligible" data-trigger="hover" data-content="This user is not eligible to be a PI!">
-                <span class="badge badge-danger"><i class="fas fa-exclamation-circle"></i></span><span class="sr-only">${new_content}</span>
-              </a>
+                <a id="id_ineligible" href="#" class="notnavigable" data-toggle="popover" title="Not Eligible" data-trigger="hover" data-content="This user is not eligible to be a PI!">
+                  <span class="badge badge-danger"><i class="fas fa-exclamation-circle"></i></span><span class="sr-only">${new_content}</span>
+                </a>
               {% endif %}
             </td>
             <td>{{ project_review.project_updates|truncatechars:50 }}</td>
@@ -126,6 +133,19 @@ Project Review List
     <div class="modal-content">
       <div class="modal-header">
         <h4 class="modal-title" id="id_pi_projects_label">PI Projects</h4>
+        
+        <a
+          style="font-size: 1.4em;"
+          id="id_ineligible_modal"
+          href="#"
+          class="notnavigable ml-1"
+          data-toggle="popover"
+          title="Not Eligible"
+          data-trigger="hover"
+          data-content="This user is not eligible to be a PI!"
+        \>
+          <span class="badge badge-danger"><i class="fas fa-exclamation-circle"></i></span><span class="sr-only">${new_content}</span>
+        </a>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -151,6 +171,13 @@ Project Review List
     var link = $(event.relatedTarget);
     var pi = link.data('pi');
     var pk = link.data('pk');
+    var eligible = link.data('eligible');
+    console.log(eligible);
+    if (eligible === 'False') {
+      $('#id_ineligible_modal').show();
+    } else {
+      $('#id_ineligible_modal').hide();
+    }
     var modal = $(this);
     for (let i = 0; i < pi_projects.length; i++) {
       project = pi_projects[i]

--- a/coldfront/components/site/templates/project/project_review_list.html
+++ b/coldfront/components/site/templates/project/project_review_list.html
@@ -88,7 +88,7 @@ Project Review List
                 {{ project_review.project.pi.first_name }} {{ project_review.project.pi.last_name }} ({{ project_review.project.pi.username }})
               </a>
               {% if not pi_eligibilities|get_value_from_dict:project_review.project.pi.username %}
-              <a href="#" data-toggle="popover" title="Not Eligible" data-trigger="hover" data-content="This user is not eligible to be a PI!">
+              <a href="#" class="notnavigable" data-toggle="popover" title="Not Eligible" data-trigger="hover" data-content="This user is not eligible to be a PI!">
                 <span class="badge badge-danger"><i class="fas fa-exclamation-circle"></i></span><span class="sr-only">${new_content}</span>
               </a>
               {% endif %}
@@ -143,6 +143,8 @@ Project Review List
   $("#navbar-admin").addClass("active");
   $("#navbar-director").addClass("active");
   $("#navbar-project-reviews").addClass("active");
+
+  $('a.notnavigable').click(function(e) {e.preventDefault();});
 
   $('#id_pi_projects_modal').on('show.bs.modal', function (event) {
     $('#id_pi_projects_modal .modal-body').html('')

--- a/coldfront/config/plugins/coldfront_custom_resources.py
+++ b/coldfront/config/plugins/coldfront_custom_resources.py
@@ -5,6 +5,7 @@ INSTALLED_APPS += [
     'coldfront_custom_resources',
     'coldfront_custom_resources.compute',
     'coldfront_custom_resources.service.posit_connect',
+    'coldfront_custom_resources.service.reallms_api',
     'coldfront_custom_resources.storage.geode_project',
     'coldfront_custom_resources.storage.slate_project'
 ]
@@ -52,6 +53,5 @@ if ENABLE_LDAP_ELIGIBILITY_SERVER:
     LDAP_ELIGIBILITY_CONNECT_TIMEOUT = ENV.str('LDAP_ELIGIBILITY_CONNECT_TIMEOUT', 2.5)
     LDAP_ADS_NETID_FORMAT = ENV.str('LDAP_ADS_NETID_FORMAT')
 
-REALLMS_URL = ENV.str('REALLMS_URL', '')
-REALLMS_ADMIN_EMAIL = ENV.str('REALLMS_ADMIN_EMAIL', '')
-REALLMS_ADMIN_PASSWORD = ENV.str('REALLMS_ADMIN_PASSWORD', '')
+REALLMS_API_URL = ENV.str('REALLMS_API_URL', '')
+REALLMS_API_KEY = ENV.str('REALLMS_API_KEY', '')

--- a/coldfront/core/allocation/tasks.py
+++ b/coldfront/core/allocation/tasks.py
@@ -123,7 +123,7 @@ def send_expiry_emails():
                         email_receiver_list
                         ) 
 
-            logger.debug(f'Allocation(s) expiring in soon, email sent to user {user}.')
+            logger.debug(f'Allocation(s) expiring email sent to user {user}.')
 
     #Allocations expired
     admin_projectdict = {}

--- a/coldfront/core/allocation/tasks.py
+++ b/coldfront/core/allocation/tasks.py
@@ -116,7 +116,7 @@ def send_expiry_emails():
                                     )
                             
         if email_receiver_list:
-            send_email_template(f'Your access to {CENTER_NAME}\'s resources is expiring soon',
+            send_email_template(f'Your access to {CENTER_NAME} allocations is expiring soon',
                         'email/allocation_expiring.txt',
                         template_context,
                         EMAIL_TICKET_SYSTEM_ADDRESS,
@@ -206,7 +206,7 @@ def send_expiry_emails():
                             
         if email_receiver_list:
 
-            send_email_template('Your access to resource(s) have expired',
+            send_email_template(f'Access to your {CENTER_NAME} allocations has expired',
                         'email/allocation_expired.txt',
                         template_context,
                         EMAIL_TICKET_SYSTEM_ADDRESS,

--- a/coldfront/core/allocation/tasks.py
+++ b/coldfront/core/allocation/tasks.py
@@ -62,7 +62,7 @@ def send_expiry_emails():
             for allocationuser in user.allocationuser_set.all():
                 allocation = allocationuser.allocation
 
-                if (((allocation.status.name in ['Active', 'Payment Pending', 'Payment Requested', 'Unpaid']) and (allocation.end_date == expring_in_days))):
+                if (((allocation.status.name in ['Active', 'Payment Pending', 'Payment Requested', 'Unpaid']) and (allocation.end_date == expring_in_days) and not allocation.project.end_date == expring_in_days)):
                     if not allocation.project.requires_review:
                         continue
 
@@ -96,7 +96,7 @@ def send_expiry_emails():
 
                     for projectuser in allocation.project.projectuser_set.filter(user=user, status__name='Active'): 
                         if ((projectuser.enable_notifications) and 
-                            (allocationuser.user == user and allocationuser.status.name__in == ['Active', 'Invited', 'Disabled'])):
+                            (allocationuser.user == user and allocationuser.status.name in ['Active', 'Invited', 'Disabled'])):
 
                             if (user.email not in email_receiver_list):
                                 email_receiver_list.append(user.email)
@@ -144,7 +144,7 @@ def send_expiry_emails():
             if not allocation.project.requires_review:
                 continue
 
-            if (allocation.end_date == expring_in_days and not allocation.is_locked):
+            if (allocation.end_date == expring_in_days and not allocation.project.end_date == expring_in_days and not allocation.is_locked):
                 
                 project_url = f'{CENTER_BASE_URL.strip("/")}/{"project"}/{allocation.project.pk}/'
 
@@ -169,7 +169,7 @@ def send_expiry_emails():
 
                 for projectuser in allocation.project.projectuser_set.filter(user=user, status__name='Active'): 
                     if ((projectuser.enable_notifications) and 
-                        (allocationuser.user == user and allocationuser.status.name == 'Active')):
+                        (allocationuser.user == user and allocationuser.status.name in ['Active', 'Invited', 'Disabled'])):
 
                         if not expire_notification or expire_notification and expire_notification.value == 'No':
 

--- a/coldfront/core/allocation/tasks.py
+++ b/coldfront/core/allocation/tasks.py
@@ -96,7 +96,7 @@ def send_expiry_emails():
 
                     for projectuser in allocation.project.projectuser_set.filter(user=user, status__name='Active'): 
                         if ((projectuser.enable_notifications) and 
-                            (allocationuser.user == user and allocationuser.status.name == 'Active')):
+                            (allocationuser.user == user and allocationuser.status.name__in == ['Active', 'Invited', 'Disabled'])):
 
                             if (user.email not in email_receiver_list):
                                 email_receiver_list.append(user.email)

--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -208,7 +208,7 @@ class ProjectRequestEmailForm(forms.Form):
 class ProjectReviewAllocationForm(forms.Form):
     pk = forms.IntegerField(disabled=True)
     resource = forms.CharField(max_length=100, disabled=True)
-    users = forms.CharField(max_length=1000, disabled=True, required=False)
+    users = forms.CharField(max_length=2000, disabled=True, required=False)
     status = forms.CharField(max_length=50, disabled=True)
     expires_on = forms.DateField(
         widget=forms.DateInput(attrs={'class': 'datepicker'}),

--- a/coldfront/core/project/tasks.py
+++ b/coldfront/core/project/tasks.py
@@ -89,7 +89,7 @@ def send_expiry_emails():
                     'help_email': EMAIL_TICKET_SYSTEM_ADDRESS,
                     'signature': EMAIL_SIGNATURE
                 }
-                send_email_template(f'Access to your {CENTER_NAME} resources is expiring soon',
+                send_email_template(f'Access to your {CENTER_NAME} projects is expiring soon',
                     'email/project_expiring.txt',
                     template_context,
                     EMAIL_TICKET_SYSTEM_ADDRESS,
@@ -136,7 +136,7 @@ def send_expiry_emails():
                 'help_email': EMAIL_TICKET_SYSTEM_ADDRESS,
                 'signature': EMAIL_SIGNATURE
             }
-            send_email_template(f'Access to your {CENTER_NAME} resources has expired',
+            send_email_template(f'Access to your {CENTER_NAME} projects has expired',
                 'email/project_expired.txt',
                 template_context,
                 EMAIL_TICKET_SYSTEM_ADDRESS,

--- a/coldfront/core/project/tasks.py
+++ b/coldfront/core/project/tasks.py
@@ -85,7 +85,7 @@ def send_expiry_emails():
                     'center_name': CENTER_NAME,
                     'expiring_in_days': days_remaining,
                     'project_dict': projects,
-                    'project_renewal_help_url': "https://servicenow.iu.edu/kb?id=kb_article_view&sysparm_article=KB0024132",
+                    'project_renewal_help_url': CENTER_PROJECT_RENEWAL_HELP_URL,
                     'help_email': EMAIL_TICKET_SYSTEM_ADDRESS,
                     'signature': EMAIL_SIGNATURE
                 }

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1797,7 +1797,9 @@ class ProjectReviewListView(LoginRequiredMixin, UserPassesTestMixin, TemplateVie
             status__name__in=['Waiting For Admin Approval', 'Contacted By Admin', ]
         ).order_by('created')
         context['project_request_list'] = projects
+
         pis = set([project.pi for project in projects])
+        pis = pis.union(set([project_review.project.pi for project_review in project_reviews]))
         pi_project_objs = Project.objects.filter(
             pi__in=pis,
             status__name__in=[

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1787,7 +1787,7 @@ class ProjectReviewListView(LoginRequiredMixin, UserPassesTestMixin, TemplateVie
         context = super().get_context_data(**kwargs)
 
         project_reviews = ProjectReview.objects.filter(
-            status__name__in=['Pending', 'Contacted By Admin', ])
+            status__name__in=['Pending', 'Contacted By Admin', ]).order_by('created')
         pi_eligibilities = check_if_pis_eligible(
             set([project_review.project.pi for project_review in project_reviews]))
         context['project_review_list'] = project_reviews
@@ -1795,7 +1795,7 @@ class ProjectReviewListView(LoginRequiredMixin, UserPassesTestMixin, TemplateVie
 
         projects = Project.objects.filter(
             status__name__in=['Waiting For Admin Approval', 'Contacted By Admin', ]
-        )
+        ).order_by('created')
         context['project_request_list'] = projects
         pis = set([project.pi for project in projects])
         pi_project_objs = Project.objects.filter(

--- a/coldfront/plugins/academic_analytics/utils.py
+++ b/coldfront/plugins/academic_analytics/utils.py
@@ -13,6 +13,8 @@ ORACLE_DB_PASSWORD = import_from_settings('ORACLE_DB_PASSWORD')
 ORACLE_DB_DSN = import_from_settings('ORACLE_DB_DSN')
 ORACLE_DB_QUERY = import_from_settings('ORACLE_DB_QUERY')
 
+logger = logging.getLogger(__name__)
+
 
 def get_user_ids(usernames):
     """
@@ -37,11 +39,15 @@ def format_author(author):
     authors_split = author.split('|')
     for author in authors_split:
         author_split = author.split(',')
-        if not len(author_split):
-            author_split = author.split(' ')
-            formatted_author = f'{author_split[0].strip()} {author_split[1].strip()}'
-        else:
-            formatted_author = f'{author_split[1].strip()} {author_split[0].strip()}'
+        try:
+            if not len(author_split):
+                author_split = author.split(' ')
+                formatted_author = f'{author_split[0].strip()} {author_split[1].strip()}'
+            else:
+                formatted_author = f'{author_split[1].strip()} {author_split[0].strip()}'
+        except IndexError:
+            logger.error(f"Error finding aa auther with username: {author}")
+
         formatted_authors.append(formatted_author)
 
     return ' and '.join(formatted_authors)

--- a/coldfront/plugins/academic_analytics/utils.py
+++ b/coldfront/plugins/academic_analytics/utils.py
@@ -46,7 +46,7 @@ def format_author(author):
             else:
                 formatted_author = f'{author_split[1].strip()} {author_split[0].strip()}'
         except IndexError:
-            logger.error(f"Error finding aa auther with username: {author}")
+            logger.error(f"Error finding aa author with username: {author}")
 
         formatted_authors.append(formatted_author)
 

--- a/coldfront/plugins/movable_allocations/views.py
+++ b/coldfront/plugins/movable_allocations/views.py
@@ -55,7 +55,7 @@ class AllocationMoveView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
             return super().dispatch(request, *args, **kwargs)
 
         allocation_obj = get_object_or_404(Allocation, pk=kwargs.get("pk"))
-        if not allocation_obj.status.name == "Active":
+        if allocation_obj.status.name not in ["Active", "Renewal Requested"]:
             messages.error(request, "You cannot move an inactive allocation.")
             return HttpResponseRedirect(
                 reverse("allocation-detail", kwargs={"pk": kwargs.get("pk")})


### PR DESCRIPTION
Changes:
- Added the REALLMs API resource
- Added a task to send project oriented renewal emails
- Added the ineligible icon to the PI project list modal
- Included projects in the PI project list that expired recently
- Allowed allocations with the “Pending Renewal” status to be moved
- Change allocation expiry emails to only be sent if a project has been renewed
- Fixed typos in renewal email
- Fixed an error occurring when a project is being renewed with an allocation with a lot of users in it
- Fixed project request/renewal ordering
- Fixed the incorrect title on the project renewal detail page
- Fixed users not receiving renewal emails when they should be
- Fixed PIs of project renewals not being taken into account in the PI project list
- Fixed ineligible icon causing the page to jump to the top when clicked
- The academic analytics plugin no longer errors when there is a problem with a user’s name